### PR TITLE
fix: skip composer install if composer is not available

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint:fix": "eslint --report-unused-disable-directives --fix 'src/**/*.ts*'",
     "generate:types": "ts-node src/php-parser/generate-types.ts",
     "preinstall": "npx only-allow pnpm",
-    "postinstall": "composer install",
+    "postinstall": "command -v composer >/dev/null 2>&1 && composer install || echo 'Composer not found, skipping.'",
     "prepare": "husky install"
   },
   "repository": "https://github.com/RightCapitalHQ/php-parser",


### PR DESCRIPTION
This is a temporary workaround to prevent errors in the Renovate environment.

We should find a more robust solution that ensures `composer install` is run where necessary.