### PR TITLE
fix(renovate): override`postUpdateOptions` in renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "automergeType": "pr",
   "platformAutomerge": true,
   "prCreation": "immediate",
+  "postUpdateOptions": [],
   "postUpgradeTasks": {
     "commands": [
       "git add --all",


### PR DESCRIPTION
## Motivation

This PR addresses an issue we've been encountering with our Renovate configuration, where the `pnpm dedupe` command inadvertently triggers the `postinstall` script, leading to a `composer: not found` error in our [PRs initiated by Renovate](https://github.com/RightCapitalHQ/php-parser/pull/3).

Upon investigation, we found that the `pnpm install` command, which should theoretically not trigger `postinstall` due to the `--ignore-scripts` flag, was not the source of the issue. Instead, the `postinstall` Øscript was being executed during the `pnpm dedupe` command.

Further investigation revealed that the `pnpm dedupe` command was being run due to the [`postUpdateOptions` setting](https://github.com/RightCapitalHQ/renovate-config/blob/main/default.json#L26) in the `github>RightCapitalHQ/renovate-config` configuration that we're extending from. This setting includes `pnpmDedupe`, which is why `pnpm dedupe` is being executed.

In the context of Renovate's dependency updates, we do not need to run `postinstall`, and the execution of `composer install` within `postinstall` is causing issues due to the absence of Composer in the Renovate environment.

To temporarily resolve the `composer: not found` issue and prevent the unwanted execution of `postinstall`, this PR overrides the `postUpdateOptions` in our repository's Renovate configuration, removing `pnpmDedupe`