### PR TITLE
feat: support using environment variable to overwrite `PHP_PARSER_BINARY`

### DIFF
--- a/change/@rightcapital-php-parser-ba292c61-5244-4589-8333-4bf8241a040a.json
+++ b/change/@rightcapital-php-parser-ba292c61-5244-4589-8333-4bf8241a040a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: support using environment variable to overwrite `PHP_PARSER_BINARY`",
+  "packageName": "@rightcapital/php-parser",
+  "email": "yilunsun11@yeah.net",
+  "dependentChangeType": "patch"
+}

--- a/src/php-parser/helpers/cli-helpers.ts
+++ b/src/php-parser/helpers/cli-helpers.ts
@@ -5,7 +5,15 @@ import { resolve } from 'path';
 import { PROJECT_ROOT } from '../../constants';
 import type { NodeTypeInheritingFromNodeAbstract } from '../types/types';
 
-const PHP_PARSER_BINARY = resolve(PROJECT_ROOT, 'vendor', 'bin', 'php-parse');
+const defaultPhpParserBinaryPath = resolve(
+  PROJECT_ROOT,
+  'vendor',
+  'bin',
+  'php-parse',
+);
+const PHP_PARSER_BINARY =
+  process.env.PHP_PARSER_BINARY_PATH || defaultPhpParserBinaryPath;
+
 // Avoid ENOBUFS for large output, increase buffer size to 50m
 // https://stackoverflow.com/questions/46818563/buffer-returned-by-child-process-execsync-is-incomplete/51408070
 const MAX_BUFFER_SIZE_FOR_PHP_BINARY_OUTPUT = 10 * 1024 * 1024;


### PR DESCRIPTION
目的是令使用的 `php-parse` 二进制文件路径可配置。这样 `php-parser-ast-viewer` 在 Vercel 部署时，可以利用环境变量指定非常规的二进制文件路径。