### PR TITLE
ci: workaround Renvoate `postUpgradeTasks` restriction for generating changefiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,27 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+  check-renovate-changefile:
+    if: startsWith(github.event.pull_request.head.ref, 'renovate/') && github.base_ref == github.event.repository.default_branch
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.RENOVATE_AUTO_BEACHBALL_CHANGEFILE_TOKEN }}
+
+      # Install dependencies (example using pnpm)
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install
+
+      - name: Check and generate changefile for Renovate
+        uses: RightCapitalHQ/frontend-style-guide/.github/actions/renovate-auto-beachball-changefile@main
+
   check-beachball-changefile:
     if: github.base_ref == github.event.repository.default_branch
     needs: install

--- a/change/@rightcapital-php-parser-cedd2f7b-9c38-47d5-b609-8a23ffc1cb03.json
+++ b/change/@rightcapital-php-parser-cedd2f7b-9c38-47d5-b609-8a23ffc1cb03.json
@@ -1,0 +1,7 @@
+{
+  "comment": "ci: workaround Renvoate `postUpgradeTasks` restriction for generating changefiles",
+  "type": "none",
+  "packageName": "@rightcapital/php-parser",
+  "email": "im@pyonpyon.today",
+  "dependentChangeType": "none"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -7,27 +7,11 @@
   "automergeType": "pr",
   "platformAutomerge": true,
   "prCreation": "immediate",
-  "postUpgradeTasks": {
-    "commands": [
-      "git add --all",
-      "npx beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
-      "git reset"
-    ],
-    "executionMode": "branch",
-    "fileFilters": ["change/*.json"]
-  },
+  "commitBody": "Beachball-bump-type: patch",
   "lockFileMaintenance": {
     "automerge": true,
     "enabled": true,
-    "postUpgradeTasks": {
-      "commands": [
-        "git add --all",
-        "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
-        "git reset"
-      ],
-      "executionMode": "branch",
-      "fileFilters": ["change/*.json"]
-    }
+    "commitBody": "Beachball-bump-type: none"
   },
   "packageRules": [
     {
@@ -44,15 +28,7 @@
       "groupName": "DevDependencies",
       "groupSlug": "auto-merge-dev-dependencies-updates",
       "matchDepTypes": ["devDependencies"],
-      "postUpgradeTasks": {
-        "commands": [
-          "git add --all",
-          "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
-          "git reset"
-        ],
-        "fileFilters": ["change/*.json"],
-        "executionMode": "branch"
-      }
+      "commitBody": "Beachball-bump-type: none"
     }
   ]
 }


### PR DESCRIPTION
A secret named `RENOVATE_AUTO_BEACHBALL_CHANGEFILE_TOKEN` with a token that have write access to this repository is required for this PR to work.
